### PR TITLE
Drop support for IPython<1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 zip_safe = false
 install_requires =
     sopel>=7.0
-    ipython<6.0; python_version < '3.3'
+    ipython>=4.0,<6.0; python_version < '3.3'
     ipython>=6.0,<7.0; python_version >= '3.3' and python_version < '3.5'
     ipython>=7.0,<8.0; python_version >= '3.5'
 

--- a/sopel_ipython/__init__.py
+++ b/sopel_ipython/__init__.py
@@ -2,6 +2,7 @@
 """
 ipython.py - Sopel IPython Console Module
 Copyright © 2014, Elad Alfassa <elad@fedoraproject.org>
+Copyright © 2022, dgw, technobabbl.es
 Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
@@ -13,11 +14,7 @@ import sys
 import sopel
 import sopel.module
 
-import IPython
-if hasattr(IPython, 'terminal'):
-    from IPython.terminal.embed import InteractiveShellEmbed
-else:
-    from IPython.frontend.terminal.embed import InteractiveShellEmbed
+from IPython.terminal.embed import InteractiveShellEmbed
 
 
 console = None


### PR DESCRIPTION
It's been almost a decade. Just enforce installing a version at least new enough that it doesn't have the `frontend` submodule.