### PR TITLE
Disable IPython terminal history

### DIFF
--- a/sopel_ipython/__init__.py
+++ b/sopel_ipython/__init__.py
@@ -15,9 +15,14 @@ import sopel
 import sopel.module
 
 from IPython.terminal.embed import InteractiveShellEmbed
+from traitlets.config import Config
 
 
 console = None
+# need to disable history to avoid SQLite ProgrammingError exceptions
+# see https://github.com/ipython/ipython/issues/680 for other workaround ideas
+ipython_config = Config()
+ipython_config.HistoryManager.enabled = False
 
 
 @sopel.module.commands('console')
@@ -48,7 +53,7 @@ def interactive_shell(bot, trigger):
     exitmsg = 'Interactive shell closed'
 
     console = InteractiveShellEmbed(banner1=banner1, banner2=banner2,
-                                    exit_msg=exitmsg)
+                                    exit_msg=exitmsg, config=ipython_config)
 
     bot.memory['iconsole_running'] = True
     bot.say('console started')


### PR DESCRIPTION
Letting IPython save the history causes `ProgrammingError` exceptions at Sopel shutdown, due to what I can only assume are conflicts between how IPython uses threads and how Sopel uses threads.

It's a long-standing issue; one issue thread I found full of workarounds to try (ipython/ipython#680) had been open since 2011.

### Note
I'm not sure yet exactly how I want to reconcile this with #1, as I think the new direct dependence on `traitlets` also means requiring a newer version of `IPython` than that patch does. What I _really_ don't want to do is introduce another conditional import right after eliminating one just days earlier.