### PR TITLE
Support only Sopel 8+ & Python 3.8+, with IPython 8+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,22 +14,20 @@ classifiers =
     License :: Eiffel Forum License (EFL)
     License :: OSI Approved :: Eiffel Forum License
     Operating System :: POSIX :: Linux
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Communications :: Chat :: Internet Relay Chat
 
 [options]
 packages = find:
 zip_safe = false
+python_requires = >=3.8
 install_requires =
-    sopel>=7.0
-    ipython>=4.0,<6.0; python_version < '3.3'
-    ipython>=6.0,<7.0; python_version >= '3.3' and python_version < '3.5'
-    ipython>=7.0,<8.0; python_version >= '3.5'
+    sopel>=8.0
+    ipython>=8.0
 
 [options.entry_points]
 sopel.plugins =


### PR DESCRIPTION
Simply dropping support for the older stuff (IPython<=7 especially) might take care of #3 without any actual code work.

Still need to test reverting #2 before calling a new plugin release done, though.