### PR TITLE
Revert #2: reenable IPython terminal history

### DIFF
--- a/sopel_ipython/__init__.py
+++ b/sopel_ipython/__init__.py
@@ -15,14 +15,9 @@ import sopel
 import sopel.module
 
 from IPython.terminal.embed import InteractiveShellEmbed
-from traitlets.config import Config
 
 
 console = None
-# need to disable history to avoid SQLite ProgrammingError exceptions
-# see https://github.com/ipython/ipython/issues/680 for other workaround ideas
-ipython_config = Config()
-ipython_config.HistoryManager.enabled = False
 
 
 @sopel.module.commands('console')
@@ -53,7 +48,7 @@ def interactive_shell(bot, trigger):
     exitmsg = 'Interactive shell closed'
 
     console = InteractiveShellEmbed(banner1=banner1, banner2=banner2,
-                                    exit_msg=exitmsg, config=ipython_config)
+                                    exit_msg=exitmsg)
 
     bot.memory['iconsole_running'] = True
     bot.say('console started')


### PR DESCRIPTION
This reverts commit 0db6bd2235b90849d5b504f418ada5410fae0312, reversing changes made to 6b0d9236b129e662cfefe2c6e873aa30887a2b46.

Following up #4, where I said I wanted to test out doing this. It's possible I'll need to wait until Sopel 8.0.0 is officially out, but I can probably still test this by overriding the dependency to allow 8.0.0.dev0 from the upstream `master` branch.

Note that this well and truly closes #3 if it works—or even if not, since disabling history should also prevent the error.

Meanwhile the package also needs converting from `setup.cfg` to `pyproject.toml` before the "real" release. My next job…